### PR TITLE
Format changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,47 +1,75 @@
-# 1.7.1 -- fix correctness
+# Changelog
+All notable changes to this project will be documented in this file.
 
-1. Update bn.js to fix hex encoding bug for certain large numbers
-2. Add package-lock.json
-3. fork as @metamask/number-to-bn
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 1.7.0 -- remove console log
+## [Unreleased]
 
-1. Remove bad console log
+## [1.7.1]
+### Changed
+- fix correctness
+  - Update bn.js to fix hex encoding bug for certain large numbers
+  - Add package-lock.json
+  - fork as @metamask/number-to-bn
 
-# 1.6.0 -- empty hex to zero
+## [1.7.0]
+### Changed
+- remove console log
+  - Remove bad console log
 
-1. Empty hex 0x -> 0
+## [1.6.0]
+### Changed
+- empty hex to zero
+  - Empty hex 0x -> 0
 
-# 1.5.0 -- hex number fix
+## [1.5.0]
+### Changed
+- hex number fix
+  - Fixed hex number convetion, now if hex prefixed, always assumes base 16
 
-1. Fixed hex number convetion, now if hex prefixed, always assumes base 16
+## [1.4.0]
+### Changed
+- fix hex number
+  - Fix hex number shim
+  - More test cases added
 
-# 1.4.0 -- fix hex number
+## [1.3.0]
+### Changed
+- better everythign
+  - Better error messages
+  - Added umd builds
+  - Far more comprehensive testing coverage
+  - Far more support for hex string coverage
+  - Far more support for number string coverage
+  - Less lines of code, more bang for your buck
+  - More config
 
-1. Fix hex number shim
-2. More test cases added
+## [1.2.0]
+### Changed
+- decimal number fix
+  - now throws under decimal number
 
-# 1.3.0 -- better everythign
+## [1.1.0]
+### Changed
+- es5 support
+  - es5 support
 
-1. Better error messages
-2. Added umd builds
-3. Far more comprehensive testing coverage
-4. Far more support for hex string coverage
-5. Far more support for number string coverage
-6. Less lines of code, more bang for your buck
-7. More config
+## [0.0.1]
+### Changed
+- number-to-bn
+  - Basic testing
+  - Basic docs
+  - License
+  - basic exports
 
-# 1.2.0 -- decimal number fix
-
-1. now throws under decimal number
-
-# 1.1.0 -- es5 support
-
-1. es5 support
-
-# 0.0.1 -- number-to-bn
-
-1. Basic testing
-2. Basic docs
-3. License
-4. basic exports
+[Unreleased]: https://github.com/MetaMask/number-to-bn/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/MetaMask/number-to-bn/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/MetaMask/number-to-bn/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/MetaMask/number-to-bn/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/MetaMask/number-to-bn/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/MetaMask/number-to-bn/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/MetaMask/number-to-bn/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/MetaMask/number-to-bn/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/MetaMask/number-to-bn/compare/v0.0.1...v1.1.0
+[0.0.1]: https://github.com/MetaMask/number-to-bn/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.7.1]
 ### Changed
+- fork as @metamask/number-to-bn
+
+### Fixed
 - fix correctness
   - Update bn.js to fix hex encoding bug for certain large numbers
-  - Add package-lock.json
-  - fork as @metamask/number-to-bn
 
 ## [1.7.0]
 ### Changed
-- remove console log
-  - Remove bad console log
+- Remove bad console log
 
 ## [1.6.0]
 ### Changed
@@ -24,21 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Empty hex 0x -> 0
 
 ## [1.5.0]
-### Changed
-- hex number fix
-  - Fixed hex number convetion, now if hex prefixed, always assumes base 16
+### Fixed
+- Fixed hex number convetion, now if hex prefixed, always assumes base 16
 
 ## [1.4.0]
-### Changed
-- fix hex number
-  - Fix hex number shim
-  - More test cases added
+### Fixed
+- Fix hex number shim
 
 ## [1.3.0]
+### Added
+- Added umd builds
+
 ### Changed
 - better everythign
   - Better error messages
-  - Added umd builds
   - Far more comprehensive testing coverage
   - Far more support for hex string coverage
   - Far more support for number string coverage
@@ -46,25 +43,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - More config
 
 ## [1.2.0]
-### Changed
+### Fixed
 - decimal number fix
   - now throws under decimal number
 
 ## [1.1.0]
-### Changed
+### Added
 - es5 support
-  - es5 support
 
 ## [0.0.1]
-### Changed
+### Added
 - number-to-bn
   - Basic testing
   - Basic docs
   - License
   - basic exports
 
-[Unreleased]: https://github.com/MetaMask/number-to-bn/compare/v1.7.1...HEAD
-[1.7.1]: https://github.com/MetaMask/number-to-bn/compare/v1.7.0...v1.7.1
+[Unreleased]: https://github.com/MetaMask/number-to-bn/compare/v1.7.0...HEAD
 [1.7.0]: https://github.com/MetaMask/number-to-bn/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/MetaMask/number-to-bn/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/MetaMask/number-to-bn/compare/v1.4.0...v1.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/number-to-bn",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/number-to-bn",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "description": "A simple method that will convert numbers, hex, BN or bignumber.js object into a BN.js object.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- Format `CHANGELOG.md` to support automated releasing
- Drop version from `1.7.1` to `1.7.0` (`1.7.1` was never actually published)